### PR TITLE
Let managers handle get_kernel_path()

### DIFF
--- a/hybridcontents/hybridmanager.py
+++ b/hybridcontents/hybridmanager.py
@@ -323,3 +323,11 @@ class HybridContentsManager(ContentsManager):
         self._validate_path(new_prefix, new_mgr_path)
 
         return new_mgr.rename(old_mgr_path, new_mgr_path)
+
+    @outside_root_to_404
+    def get_kernel_path(self, path, model=None):
+        prefix, mgr, mgr_path = _resolve_path(path, self.managers)
+
+        self._validate_path(prefix, mgr_path)
+
+        return mgr.get_kernel_path(mgr_path)

--- a/hybridcontents/hybridmanager.py
+++ b/hybridcontents/hybridmanager.py
@@ -328,6 +328,4 @@ class HybridContentsManager(ContentsManager):
     def get_kernel_path(self, path, model=None):
         prefix, mgr, mgr_path = _resolve_path(path, self.managers)
 
-        self._validate_path(prefix, mgr_path)
-
-        return mgr.get_kernel_path(mgr_path)
+        return mgr.get_kernel_path(mgr_path, model)

--- a/hybridcontents/tests/test_hybrid_manager.py
+++ b/hybridcontents/tests/test_hybrid_manager.py
@@ -341,6 +341,24 @@ class MultiRootTestCase(TestCase):
         with assertRaisesHTTPError(self, INVALID_PATH_ERROR):
             cm.new_untitled(path='A', ext='.yaml')
 
+    def test_kernel_path(self):
+        # We are using FileContentsManager for all roots in test, so kernel
+        # paths should be same as notebook paths
+        cm = self.contents_manager
+
+        for prefix, real_dir in iteritems(self.temp_dir_names):
+            # Notebook in main dir - kernel path is '' (relative to main dir)
+            model = cm.new_untitled(path=prefix, type='notebook')
+            path = model['path']
+            self.assertEqual(cm.get_kernel_path(path), '')
+            # Test notebook in sub-directory
+            sub_dir = 'foo'
+            mkdir(osjoin(real_dir, sub_dir))
+            prefixed_sub_dir = pjoin(prefix, sub_dir)
+            model = cm.new_untitled(path=prefixed_sub_dir, type='notebook')
+            path = model['path']
+            self.assertEqual(cm.get_kernel_path(path), sub_dir)
+
     def tearDown(self):
         for dir_ in itervalues(self.temp_dirs):
             dir_.cleanup()


### PR DESCRIPTION
This should help passthrough the correct kernel path that would be returned by underlying contents managers (eg `FileContentsManager`) - useful for deployments with a FileContentsManager for native FS, and another contents manager.

Currently, `HybridContentsManager` inherits the `ContentsManager` method which returns `''` by default. As such, all Jupyter notebook kernels end up running in the notebook server home directory.

There are a restriction on the notebook kernel end, requiring that the kernel path be a relative API path: https://github.com/jupyter/notebook/blob/8a674771564789b5468e64fae4732f83046e5e73/notebook/services/kernels/kernelmanager.py#L157-L159
As such, I chose to implement a straight passthrough from the underlying contents managers, as opposed to pre-pending the contents manager's `root_dir`.