### PR TITLE
Switch to the LargeFileManager in Examples and Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ c = get_config()
 c.NotebookApp.contents_manager_class = HybridContentsManager
 
 c.HybridContentsManager.manager_classes = {
+    # NOTE: LargFileManager only exists in notebook > 5
+    # If using notebook < 5, use FileContentManager instead
     "": LargeFileManager,
     "shared": S3ContentsManager
 }

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ c = get_config()
 c.NotebookApp.contents_manager_class = HybridContentsManager
 
 c.HybridContentsManager.manager_classes = {
-    "": FileContentsManager,
+    "": LargeFileManager,
     "shared": S3ContentsManager
 }
 
 # Each item will be passed to the constructor of the appropriate content manager.
 c.HybridContentsManager.manager_kwargs = {
-    # Args for root FileContentsManager
+    # Args for root LargeFileManager
     "": {
         "root_dir": read_only_dir
     },

--- a/examples/hybrid_manager_example.py
+++ b/examples/hybrid_manager_example.py
@@ -23,10 +23,8 @@ from hybridcontents import HybridContentsManager
 from pgcontents.pgmanager import PostgresContentsManager
 from s3contents import S3ContentsManager, GCSContentsManager
 
-# Using Jupyter (IPython >= 4.0).
-# from notebook.services.contents.filemanager import FileContentsManager
-# Using Legacy IPython.
-from IPython.html.services.contents.filemanager import FileContentsManager
+# LargeFileManager is the default Jupyter content manager
+from notebook.services.contents.largefilemanager import LargeFileManager
 
 c = get_config()
 
@@ -34,13 +32,13 @@ c = get_config()
 c.NotebookApp.contents_manager_class = HybridContentsManager
 
 c.HybridContentsManager.manager_classes = {
-    # Associate the root directory with a FileContentsManager,
+    # Associate the root directory with a LargeFileManager,
     # This manager will receive all requests that don't fall under any of the
     # other managers.
     # If you want to make this path un-editable you can configure it to use a read-only filesystem
-    '': FileContentsManager,
-    # Associate /directory with a FileContentsManager.
-    'directory': FileContentsManager,
+    '': LargeFileManager,
+    # Associate /directory with a LargeFileManager.
+    'directory': LargeFileManager,
     # Associate the postgres directory with a PostgresContentManager
     'postgres': PostgresContentsManager,
     # Associate the s3 directory with AWS S3
@@ -50,11 +48,11 @@ c.HybridContentsManager.manager_classes = {
 }
 
 c.HybridContentsManager.manager_kwargs = {
-    # Args for the FileContentsManager mapped to /directory
+    # Args for the LargeFileManager mapped to /directory
     '': {
         'root_dir': '/tmp/read-only',
     },
-    # Args for the FileContentsManager mapped to /directory
+    # Args for the LargeFileManager mapped to /directory
     'directory': {
         'root_dir': '/home/viaduct/local_directory',
     },

--- a/examples/hybrid_manager_example.py
+++ b/examples/hybrid_manager_example.py
@@ -24,6 +24,8 @@ from pgcontents.pgmanager import PostgresContentsManager
 from s3contents import S3ContentsManager, GCSContentsManager
 
 # LargeFileManager is the default Jupyter content manager
+# NOTE: LargFileManager only exists in notebook > 5
+# If using notebook < 5, use FileContentManager instead
 from notebook.services.contents.largefilemanager import LargeFileManager
 
 c = get_config()

--- a/hybridcontents/tests/test_hybrid_manager.py
+++ b/hybridcontents/tests/test_hybrid_manager.py
@@ -19,7 +19,7 @@ from mock import Mock
 
 from IPython.utils.tempdir import TemporaryDirectory
 from notebook.services.contents.tests.test_manager import TestContentsManager
-from notebook.services.contents.filemanager import FileContentsManager
+from notebook.services.contents.largefilemanager import LargeFileManager
 from notebook.services.contents.tests.test_contents_api import APITest
 
 from hybridcontents import HybridContentsManager
@@ -44,8 +44,8 @@ class FileTestCase(TestContentsManager):
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         self.td = self._temp_dir.name
-        self._file_manager = FileContentsManager(root_dir=self.td,
-                                                 delete_to_trash=False)
+        self._file_manager = LargeFileManager(root_dir=self.td,
+                                              delete_to_trash=False)
         self.contents_manager = HybridContentsManager(
             managers={'': self._file_manager})
 
@@ -68,8 +68,8 @@ class MultiRootTestCase(TestCase):
             for prefix, v in iteritems(self.temp_dirs)
         }
         self._managers = {
-            prefix: FileContentsManager(root_dir=self.temp_dir_names[prefix],
-                                        delete_to_trash=False)
+            prefix: LargeFileManager(root_dir=self.temp_dir_names[prefix],
+                                     delete_to_trash=False)
             for prefix in mgr_roots
         }
         self.contents_manager = HybridContentsManager(managers=self._managers)
@@ -342,7 +342,7 @@ class MultiRootTestCase(TestCase):
             cm.new_untitled(path='A', ext='.yaml')
 
     def test_kernel_path(self):
-        # We are using FileContentsManager for all roots in test, so kernel
+        # We are using LargeFileManager for all roots in test, so kernel
         # paths should be same as notebook paths
         cm = self.contents_manager
 

--- a/hybridcontents/tests/test_hybrid_manager.py
+++ b/hybridcontents/tests/test_hybrid_manager.py
@@ -19,7 +19,7 @@ from mock import Mock
 
 from IPython.utils.tempdir import TemporaryDirectory
 from notebook.services.contents.tests.test_manager import TestContentsManager
-from notebook.services.contents.largefilemanager import LargeFileManager
+from notebook.services.contents.filemanager import FileContentsManager
 from notebook.services.contents.tests.test_contents_api import APITest
 
 from hybridcontents import HybridContentsManager
@@ -44,8 +44,8 @@ class FileTestCase(TestContentsManager):
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         self.td = self._temp_dir.name
-        self._file_manager = LargeFileManager(root_dir=self.td,
-                                              delete_to_trash=False)
+        self._file_manager = FileContentsManager(root_dir=self.td,
+                                                 delete_to_trash=False)
         self.contents_manager = HybridContentsManager(
             managers={'': self._file_manager})
 
@@ -68,8 +68,8 @@ class MultiRootTestCase(TestCase):
             for prefix, v in iteritems(self.temp_dirs)
         }
         self._managers = {
-            prefix: LargeFileManager(root_dir=self.temp_dir_names[prefix],
-                                     delete_to_trash=False)
+            prefix: FileContentsManager(root_dir=self.temp_dir_names[prefix],
+                                        delete_to_trash=False)
             for prefix in mgr_roots
         }
         self.contents_manager = HybridContentsManager(managers=self._managers)
@@ -342,7 +342,7 @@ class MultiRootTestCase(TestCase):
             cm.new_untitled(path='A', ext='.yaml')
 
     def test_kernel_path(self):
-        # We are using LargeFileManager for all roots in test, so kernel
+        # We are using FileContentsManager for all roots in test, so kernel
         # paths should be same as notebook paths
         cm = self.contents_manager
 


### PR DESCRIPTION
https://jupyter-notebook.readthedocs.io/en/stable/config.html

The default Jupyter notebook file manager is `notebook.services.contents.largefilemanager.LargeFileManager`, it extends the basic `FileContentManager`.

We should use it in the examples and tests