### PR TITLE
Get ContentsManager from the new location, but still support the old

### DIFF
--- a/hybridcontents/hybridmanager.py
+++ b/hybridcontents/hybridmanager.py
@@ -4,7 +4,12 @@ from __future__ import unicode_literals
 from six import iteritems
 from tornado.web import HTTPError
 
-from notebook.services.contents.manager import ContentsManager
+try:
+    # new source for ContentsManager
+    from jupyter_server.services.contents.manager import ContentsManager
+except ImportError:
+    # old way of importing from the notebook package
+    from notebook.services.contents.manager import ContentsManager
 
 from traitlets import Dict
 


### PR DESCRIPTION
When running this contents manager with a new-ish jupyter stack, I get the following error:
```
[W 2023-01-12 20:30:19.627 SingleUserLabApp manager:354] jupyterlab | error linking extension: The 'contents_manager_class' trait of a SingleUserLabApp instance expected a
 subclass of 'jupyter_server.services.contents.manager.ContentsManager', not the HybridContentsManager HybridContentsManager.
    Traceback (most recent call last):
      File "/opt/envs/system/suns/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 348, in link_extension
        extension.link_all_points(self.serverapp)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 230, in link_all_points
        self.link_point(point_name, serverapp)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 220, in link_point
        point.link(serverapp)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/jupyter_server/extension/manager.py", line 136, in link
        linker(serverapp)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/jupyter_server/extension/application.py", line 403, in _link_jupyter_server_extension
        self.serverapp.update_config(self.config)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/config/configurable.py", line 230, in update_config
        self._load_config(config)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/config/configurable.py", line 181, in _load_config
        setattr(self, name, deepcopy(config_value))
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/traitlets.py", line 732, in __set__
        self.set(obj, value)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/traitlets.py", line 706, in set
        new_value = self._validate(obj, value)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/traitlets.py", line 738, in _validate
        value = self.validate(obj, value)
                ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/traitlets.py", line 2056, in validate
        self.error(obj, value)
      File "/opt/envs/system/suns/lib/python3.11/site-packages/traitlets/traitlets.py", line 844, in error
        raise TraitError(e)
    traitlets.traitlets.TraitError: The 'contents_manager_class' trait of a SingleUserLabApp instance expected a subclass of 'jupyter_server.services.contents.manager.ContentsManager', not the HybridContentsManager HybridContentsManager.
```

It appears to be sufficient to just update the import location to pull from the desired location that is spelled out in the stack trace.

Seems prudent to also leave the old import around so that this extension still works with older versions of jupyter